### PR TITLE
Bump valkey-glide to 2.5.2

### DIFF
--- a/docs/src/content/docs/valkey/drivers.md
+++ b/docs/src/content/docs/valkey/drivers.md
@@ -73,7 +73,7 @@ The following overview explains features that are supported by the individual Va
   <dependency>
     <groupId>io.valkey</groupId>
     <artifactId>valkey-glide</artifactId>
-    <version>2.4.0</version>
+    <version>${version}</version>
   </dependency>
 </dependencies>
 ```
@@ -136,7 +136,7 @@ For more detailed client configuration options, see `io.valkey.springframework.d
   <dependency>
     <groupId>io.lettuce</groupId>
     <artifactId>lettuce-core</artifactId>
-    <version>6.3.2.RELEASE</version>
+    <version>${version}</version>
   </dependency>
 
 </dependencies>
@@ -212,7 +212,7 @@ Netty currently supports the epoll (Linux) and kqueue (BSD/macOS) interfaces for
   <dependency>
     <groupId>valkey.clients</groupId>
     <artifactId>jedis</artifactId>
-    <version>5.1.2</version>
+    <version>${version}</version>
   </dependency>
 
 </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<springdata.parent.version>4.1.0</springdata.parent.version>
 
 		<!-- Valkey/Redis client versions -->
-		<valkey-glide.version>2.4.2</valkey-glide.version>
+		<valkey-glide.version>2.5.2</valkey-glide.version>
 		<lettuce.version>7.5.2.RELEASE</lettuce.version>
 		<jedis.version>7.4.1</jedis.version>
 		<pool.version>2.12.0</pool.version>

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ClusterGlideClientAdapter.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ClusterGlideClientAdapter.java
@@ -415,8 +415,11 @@ class ClusterGlideClientAdapter implements UnifiedGlideClient {
 			ClusterValue<?> clusterValue = nextCommandRoute == null ? glideClusterClient.customCommand(args).get()
 					: glideClusterClient.customCommand(args, nextCommandRoute).get();
 
-			// Case 1: Explicit multi-node route - return multiValue for aggregation
-			if (needToAggregateResult(nextCommandRoute)) {
+			// Case 1: Explicit multi-node route - return multiValue for aggregation.
+			// Guard with hasMultiData(): some commands routed to all primaries (e.g. SAVE)
+			// return a single value rather than a per-node map, in which case we fall
+			// through to single-value handling instead of failing.
+			if (needToAggregateResult(nextCommandRoute) && clusterValue.hasMultiData()) {
 				return clusterValue.getMultiValue();
 			}
 

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ClusterGlideClientAdapter.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ClusterGlideClientAdapter.java
@@ -176,7 +176,7 @@ class ClusterGlideClientAdapter implements UnifiedGlideClient {
 		configBuilder.subscriptionConfiguration(subConfigBuilder.build());
 
 		// Report as GlideJava(SpringDataValkey), preserving the underlying driver identity.
-		configBuilder.clientInfoTag("SpringDataValkey");
+		configBuilder.clientInfoTag(CLIENT_INFO_TAG);
 
 		// Build and create cluster client
 		GlideClusterClientConfiguration config = configBuilder.build();

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ClusterGlideClientAdapter.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ClusterGlideClientAdapter.java
@@ -175,8 +175,8 @@ class ClusterGlideClientAdapter implements UnifiedGlideClient {
 		subConfigBuilder.callback((msg, context) -> this.listener.onMessage(msg, context));
 		configBuilder.subscriptionConfiguration(subConfigBuilder.build());
 
-		// Set library name for server-side client identification
-		configBuilder.libName("GlideSpringDataValkey");
+		// Report as GlideJava(SpringDataValkey), preserving the underlying driver identity.
+		configBuilder.clientInfoTag("SpringDataValkey");
 
 		// Build and create cluster client
 		GlideClusterClientConfiguration config = configBuilder.build();

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/StandaloneGlideClientAdapter.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/StandaloneGlideClientAdapter.java
@@ -164,7 +164,7 @@ class StandaloneGlideClientAdapter implements UnifiedGlideClient {
 		configBuilder.subscriptionConfiguration(subConfigBuilder.build());
 
 		// Report as GlideJava(SpringDataValkey), preserving the underlying driver identity.
-		configBuilder.clientInfoTag("SpringDataValkey");
+		configBuilder.clientInfoTag(CLIENT_INFO_TAG);
 
 		// Build and create client
 		GlideClientConfiguration config = configBuilder.build();

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/StandaloneGlideClientAdapter.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/StandaloneGlideClientAdapter.java
@@ -163,8 +163,8 @@ class StandaloneGlideClientAdapter implements UnifiedGlideClient {
 		subConfigBuilder.callback((msg, context) -> this.listener.onMessage(msg, context));
 		configBuilder.subscriptionConfiguration(subConfigBuilder.build());
 
-		// Set library name for server-side client identification
-		configBuilder.libName("GlideSpringDataValkey");
+		// Report as GlideJava(SpringDataValkey), preserving the underlying driver identity.
+		configBuilder.clientInfoTag("SpringDataValkey");
 
 		// Build and create client
 		GlideClientConfiguration config = configBuilder.build();

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/UnifiedGlideClient.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/UnifiedGlideClient.java
@@ -29,6 +29,12 @@ import org.jspecify.annotations.Nullable;
  */
 interface UnifiedGlideClient extends AutoCloseable {
 
+	/**
+	 * Client information tag reported to the server via GLIDE's {@code clientInfoTag}, producing a
+	 * lib-name of {@code GlideJava(SpringDataValkey)} for server-side identification.
+	 */
+	String CLIENT_INFO_TAG = "SpringDataValkey";
+
 	public enum BatchStatus {
 
 		None, Pipeline, Transaction,

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClusterServerCommands.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClusterServerCommands.java
@@ -58,17 +58,14 @@ public class ValkeyGlideClusterServerCommands implements ValkeyClusterServerComm
 
 	@Override
 	public void bgReWriteAof() {
-		// valkey-glide default route is bogus - by first key, so we specify ALL_PRIMARIES.
-		// The response is discarded; accept Object since 2.5.x may return a single value
-		// rather than a per-node map for these admin commands.
-		connection.execute(SimpleMultiNodeRoute.ALL_PRIMARIES, "BGREWRITEAOF", (Object rawResult) -> null);
+		// valkey-glide default route is bogus - by first key, so we specify ALL_PRIMARIES
+		connection.execute(SimpleMultiNodeRoute.ALL_PRIMARIES, "BGREWRITEAOF", (Map<String, ?> rawResult) -> null);
 	}
 
 	@Override
 	public void bgSave() {
-		// valkey-glide default route is - random, so we specify ALL_PRIMARIES.
-		// The response is discarded; accept Object (single value or per-node map).
-		connection.execute(SimpleMultiNodeRoute.ALL_PRIMARIES, "BGSAVE", (Object rawResult) -> null);
+		// valkey-glide default route is - random, so we specify ALL_PRIMARIES
+		connection.execute(SimpleMultiNodeRoute.ALL_PRIMARIES, "BGSAVE", (Map<String, ?> rawResult) -> null);
 	}
 
 	@Override
@@ -81,7 +78,8 @@ public class ValkeyGlideClusterServerCommands implements ValkeyClusterServerComm
 
 	public void save() {
 		// valkey-glide default route is "random", so we specify ALL_PRIMARIES.
-		// The response is discarded; accept Object (single value or per-node map).
+		// GLIDE 2.5.x aggregates SAVE to a single value (rather than a per-node map);
+		// the response is discarded, so accept Object.
 		connection.execute(SimpleMultiNodeRoute.ALL_PRIMARIES, "SAVE", (Object rawResult) -> null);
 	}
 

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClusterServerCommands.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClusterServerCommands.java
@@ -58,14 +58,17 @@ public class ValkeyGlideClusterServerCommands implements ValkeyClusterServerComm
 
 	@Override
 	public void bgReWriteAof() {
-		// valkey-glide default route is bogus - by first key, so we specify ALL_PRIMARIES
-		connection.execute(SimpleMultiNodeRoute.ALL_PRIMARIES, "BGREWRITEAOF", (Map<String, ?> rawResult) -> null);
+		// valkey-glide default route is bogus - by first key, so we specify ALL_PRIMARIES.
+		// The response is discarded; accept Object since 2.5.x may return a single value
+		// rather than a per-node map for these admin commands.
+		connection.execute(SimpleMultiNodeRoute.ALL_PRIMARIES, "BGREWRITEAOF", (Object rawResult) -> null);
 	}
 
 	@Override
 	public void bgSave() {
-		// valkey-glide default route is - random, so we specify ALL_PRIMARIES
-		connection.execute(SimpleMultiNodeRoute.ALL_PRIMARIES, "BGSAVE", (Map<String, ?> rawResult) -> null);
+		// valkey-glide default route is - random, so we specify ALL_PRIMARIES.
+		// The response is discarded; accept Object (single value or per-node map).
+		connection.execute(SimpleMultiNodeRoute.ALL_PRIMARIES, "BGSAVE", (Object rawResult) -> null);
 	}
 
 	@Override
@@ -77,8 +80,9 @@ public class ValkeyGlideClusterServerCommands implements ValkeyClusterServerComm
 	}
 
 	public void save() {
-		// valkey-glide default route is "random", so we specify ALL_PRIMARIES
-		connection.execute(SimpleMultiNodeRoute.ALL_PRIMARIES, "SAVE", (Map<String, ?> rawResult) -> null);
+		// valkey-glide default route is "random", so we specify ALL_PRIMARIES.
+		// The response is discarded; accept Object (single value or per-node map).
+		connection.execute(SimpleMultiNodeRoute.ALL_PRIMARIES, "SAVE", (Object rawResult) -> null);
 	}
 
 	@Override

--- a/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClusterServerCommands.java
+++ b/spring-data-valkey/src/main/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideClusterServerCommands.java
@@ -76,6 +76,7 @@ public class ValkeyGlideClusterServerCommands implements ValkeyClusterServerComm
 				(Map<String, Long> rawResult) -> rawResult.isEmpty() ? null : Collections.max(rawResult.values()));
 	}
 
+	@Override
 	public void save() {
 		// valkey-glide default route is "random", so we specify ALL_PRIMARIES.
 		// GLIDE 2.5.x aggregates SAVE to a single value (rather than a per-node map);

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionClusterServerCommandsIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionClusterServerCommandsIntegrationTests.java
@@ -478,7 +478,8 @@ public class ValkeyGlideConnectionClusterServerCommandsIntegrationTests
 	@EnabledOnValkeyVersion("7.2")
 	void testClientLibNameReported() {
 		List<ValkeyClientInfo> clientList = clusterConnection.serverCommands().getClientList();
-		assertThat(clientList).anyMatch(client -> "GlideSpringDataValkey".equals(client.get("lib-name")));
+		assertThat(clientList).anyMatch(
+				client -> client.get("lib-name") != null && client.get("lib-name").contains("(SpringDataValkey)"));
 	}
 
 	// ==================== Cluster-Wide Routing and Aggregation Verification

--- a/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionServerCommandsIntegrationTests.java
+++ b/spring-data-valkey/src/test/java/io/valkey/springframework/data/valkey/connection/valkeyglide/ValkeyGlideConnectionServerCommandsIntegrationTests.java
@@ -481,7 +481,8 @@ public class ValkeyGlideConnectionServerCommandsIntegrationTests extends Abstrac
 	@EnabledOnValkeyVersion("7.2")
 	void testClientLibNameReported() {
 		List<ValkeyClientInfo> clientList = connection.serverCommands().getClientList();
-		assertThat(clientList).anyMatch(client -> "GlideSpringDataValkey".equals(client.get("lib-name")));
+		assertThat(clientList).anyMatch(
+				client -> client.get("lib-name") != null && client.get("lib-name").contains("(SpringDataValkey)"));
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

Bump Valkey GLIDE version to 2.5.2.

Closes #105

## Implementation

- Bump valkey-glide from 2.4.2 to 2.5.2
- Fix cluster `SAVE` failing with "No multi value stored" as 2.5.x returns `SAVE` as a single value rather than a map
- Adopt GLIDE's `clientInfoTag` (new in 2.5.x) for framework attribution instead of overriding `libName`, changing the reported lib-name from `GlideSpringDataValkey` to `GlideJava(SpringDataValkey)`

## Testing

All unit tests, examples, and manual tests pass.